### PR TITLE
OSL submodule update and misc

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
-autoreconf -i
+
+set -e
+
+# (Re)Generate autotools files
+autoreconf -vi
+
+# (Re)Generate autotools files for OSL if it exists
 if test -f osl/autogen.sh; then
-	(cd osl; ./autogen.sh)
+  (cd osl; ./autogen.sh)
 fi

--- a/submodules_get.sh
+++ b/submodules_get.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+
+set -e
+
 git submodule init
 git submodule update

--- a/submodules_update.sh
+++ b/submodules_update.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+submodule_folder_list=$(grep "path" .gitmodules | awk '{ print $NF }')
+
+for submodule in ${submodule_folder_list}; do
+  echo "*** Update submodule $submodule ***"
+  (cd "$submodule"; git pull origin master)
+  git add "$submodule"
+  if git commit -m "Update submodule $submodule"; then
+    echo "*** Commit changes on submodule $submodule ***"
+  fi
+done


### PR DESCRIPTION
The main contribution of this PR is to update the OpenSCOP submodule to version 0.9.2.

The rest of the contributions refer to:

- Renaming the get_submodules.sh script to submodules_get.sh for naming convention with respect to the other submodule script and other PERISCOP repositories. Make script fail on any error.
- Make the autogen.sh script fail on error, add verbose on autoreconf command, and do not create the autoconf folder since it is already created by the autoreconf tool. This modifications are introduced to easily detect build errors when building Clan in a larger pipeline.